### PR TITLE
fix the disable-color flag

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -295,7 +295,7 @@ func New() *Cmd {
 		fmt.Println("http://github.com/dtact/divd-2021-00038--log4j-scanner")
 		fmt.Println("--------------------------------------")
 
-		color.NoColor = c.Bool("no-color")
+		color.NoColor = c.Bool("disable-color")
 		return nil
 	}
 


### PR DESCRIPTION
The disable-color command-line flag is used to disable color.
It's used to call color.NoColor later on. But this call uses an incorrect boolean 'no-color' rather than 'disable-color'